### PR TITLE
Episode monitor (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /torrent-files
 
 .env
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /usr/
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD [ "python", "./src/tgBot.py" ]
+CMD [ "python", "./src/main.py" ]

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ python_full_version = "3.11.1"
 
 [scripts]
 build = "docker build . -t torrent-watcher"
-start = "docker run -d --name torrent-watcher --restart unless-stopped torrent-watcher"
+start = "docker run -d -v ./data:/usr/data --name torrent-watcher --restart unless-stopped torrent-watcher"

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,59 @@
+import os
+from multiprocessing import Process
+from time import sleep
+from dotenv import load_dotenv
+
+from transmission_client import TransmissionClient, download_paths, transmission_error
+from pb_orchestrator import MonitorOrchestrator, PBMonitor
+from pb_client import PBSearcher
+
+from telegram.ext import ApplicationBuilder
+from tg_bot import TgBotRunner
+
+load_dotenv()
+PERIOD_SECONDS = 60 * 60 * 24
+
+torrent_searcher = PBSearcher()
+monitors_orchestrator = MonitorOrchestrator()
+
+try:
+    transmission = TransmissionClient(
+        os.getenv("TRANSMISSION_HOST"), download_paths)
+except transmission_error.TransmissionConnectError:
+    raise "can't connect to the host"
+
+users_whitelist = [int(uid) for uid in os.getenv("ALLOWED_TG_IDS").split(",")]
+tg_client = ApplicationBuilder().token(os.getenv("TG_BOT_TOKEN")).build()
+
+runner = TgBotRunner(tg_client=tg_client, torrent_client=transmission,
+                     torrent_searcher=torrent_searcher, monitors_orchestrator=monitors_orchestrator, tg_user_whitelist=users_whitelist)
+
+
+def run_search_jobs_on_timer(timer_seconds):
+    search_results = monitors_orchestrator.run_search_jobs()
+    for found_item in search_results:
+        download_type = "show" if type(
+            found_item.job_settings.searcher) == PBMonitor else "movie"
+        magnet_link = torrent_searcher.generate_magnet_link(
+            found_item.result)
+        print(found_item.result, download_type)
+        transmission.add_download(magnet_link, download_type)
+        if not found_item.job_settings.silent:
+            runner.send_message(found_item.job_settings.owner_id,
+                                text=f"Monitor added new download!\n<b>{found_item.result.name}</b>")
+    if search_results:
+        sleep(5)
+        run_search_jobs_on_timer(timer_seconds)
+    else:
+        sleep(timer_seconds)
+        run_search_jobs_on_timer(timer_seconds)
+
+
+def bot_poll():
+    runner.tg_client.run_polling()
+
+
+if __name__ == '__main__':
+    [process.start() for process in
+     (Process(target=run_search_jobs_on_timer, args=(PERIOD_SECONDS,)),
+      Process(target=bot_poll))]

--- a/src/pb_client.py
+++ b/src/pb_client.py
@@ -29,6 +29,12 @@ class PBSearcher:
         "udp://open.stealth.si:80/announce",
     ]
 
+    def __init__(self, default_query=None) -> None:
+        self.default_query = default_query
+
+    def __repr__(self) -> str:
+        return f"(M) / {self.default_query}"
+
     @classmethod
     def generate_magnet_link(cls, torrent_details: TorrentDetails) -> str:
         trackers_list_formatted = "&tr=".join([""] + cls._trackers_list)
@@ -52,8 +58,14 @@ class PBSearcher:
             search_results_formatted, key=lambda x: x.seeds, reverse=True)
         return search_results_formatted
 
+    def look(self):
+        try:
+            return self.search_torrent(self.default_query)[0]
+        except IndexError:
+            return
 
-class PBWatcher(PBSearcher):
+
+class PBMonitor(PBSearcher):
     def __init__(self, show_name: str, season_number: int, num_episodes_skip: int, size_limit_gb: int = None, only_vips=False):
         self.show_name = show_name
         self.season_number = season_number
@@ -61,9 +73,15 @@ class PBWatcher(PBSearcher):
         self.size_limit_gb = size_limit_gb
         self.only_vips = only_vips
 
-        self.episode_number = None
+        self.episode_number = self.num_episodes_skip + 1
         self.whitelisted_statuses = (
             "vip",) if self.only_vips else ("vip", "trusted")
+
+    def __repr__(self) -> str:
+        items = ["(S)", self._generate_search_query()]
+        if self.size_limit_gb:
+            items += [f"<={self.size_limit_gb}Gb"]
+        return " / ".join(items)
 
     def _generate_search_query(self) -> str:
         return f"{self.show_name} s{self.season_number:02d}e{self.episode_number:02d}"
@@ -83,16 +101,21 @@ class PBWatcher(PBSearcher):
         available_downloads = filter(
             lambda x: x.status in self.whitelisted_statuses, available_downloads)
         try:
-            return next(available_downloads)
+            new_episode = next(available_downloads)
+            self.num_episodes_skip += 1
+            return new_episode
         except StopIteration:
             return
 
+    def look(self):
+        return self.find_new_episode()
+
 
 if __name__ == "__main__":
-    # s = PBSearcher()
-    # results = s.search_torrent("akira")
-    # [print(result) for result in results[:10]]
+    s = PBSearcher()
+    results = s.search_torrent("akira")
+    [print(result) for result in results[:10]]
 
-    w = PBWatcher("chainsaw man 1080p", 1, 5, 4)
+    w = PBMonitor("chainsaw man 1080p", 1, 5, 4)
     new_ep = w.find_new_episode()
     print(new_ep)

--- a/src/pb_orchestrator.py
+++ b/src/pb_orchestrator.py
@@ -1,0 +1,108 @@
+from pb_client import PBSearcher, PBMonitor, TorrentDetails
+import os
+from dataclasses import dataclass
+import json
+
+
+@dataclass
+class MonitorSetting:
+    owner_id: int
+    searcher: PBSearcher or PBMonitor
+    silent: bool = True
+
+
+@dataclass
+class JobResult:
+    result: TorrentDetails
+    job_settings: MonitorSetting
+
+
+class MonitorOrchestrator:
+    def __init__(self, monitor_settings_path=os.path.join(os.getcwd(), "data", "monitor_settings.json")) -> None:
+        self._monitor_settings_path = monitor_settings_path
+        self._settings: list[MonitorSetting] = []
+        self.update_monitor_settings_from_json()
+
+    def get_user_monitors(self, uid: int) -> list[MonitorSetting]:
+        return list(filter(lambda x: str(x.owner_id) == str(uid), self._settings))
+
+    def update_monitor_settings_from_json(self) -> None:
+        if not os.path.exists(self._monitor_settings_path):
+            open(self._monitor_settings_path, "w")
+        with open(self._monitor_settings_path, "r") as f:
+            try:
+                settings = json.load(f)
+            except json.decoder.JSONDecodeError:
+                settings = []
+            self._settings = list(map(self._dict_to_setting, settings))
+
+    @staticmethod
+    def _dict_to_setting(setting) -> MonitorSetting:
+        if setting.get("is_serial", True):
+            return MonitorSetting(
+                owner_id=setting["owner_id"],
+                silent=setting.get("silent", True),
+                searcher=PBMonitor(
+                    show_name=setting["query"],
+                    season_number=setting["season"],
+                    num_episodes_skip=setting["episodes_done"],
+                    size_limit_gb=setting["size_limit"],
+                )
+            )
+        return MonitorSetting(
+            owner_id=setting["owner_id"],
+            silent=setting.get("silent", True),
+            searcher=PBSearcher(
+                default_query=setting["query"]
+            )
+        )
+
+    @staticmethod
+    def _setting_to_dict(setting) -> dict:
+        setting_obj = {
+            "owner_id": setting.owner_id,
+            "silent": setting.silent,
+        }
+        if type(setting.searcher) == PBSearcher:
+            setting_obj["query"] = setting.searcher.default_query
+            setting_obj["is_serial"] = False
+        else:
+            setting_obj["query"] = setting.searcher.show_name
+            setting_obj["is_serial"] = True
+            setting_obj["season"] = setting.searcher.season_number
+            setting_obj["episodes_done"] = setting.searcher.num_episodes_skip
+            setting_obj["size_limit"] = setting.searcher.size_limit_gb
+
+        return setting_obj
+
+    def _save_settings(self) -> None:
+        with open(self._monitor_settings_path, 'w') as f:
+            settings_json = list(map(self._setting_to_dict, self._settings))
+            json.dump(settings_json, f, indent=2)
+
+    def add_monitor_job(self, setting: MonitorSetting) -> None:
+        self._settings.append(setting)
+        self._save_settings()
+
+    def delete_monitor_job(self, job) -> None:
+        self._settings.remove(job)
+        self._save_settings()
+
+    def add_monitor_job_from_dict(self, settings_dict: dict) -> None:
+        settings = self._dict_to_setting(settings_dict)
+        self.add_monitor_job(settings)
+
+    def run_search_jobs(self) -> list[JobResult]:
+        self.update_monitor_settings_from_json()
+        jobs = [JobResult(job.searcher.look(), job)
+                for job in self._settings]
+        jobs_with_results = list(filter(lambda j: j.result, jobs))
+        done_jobs = filter(lambda j: type(j.job_settings.searcher)
+                           == PBSearcher, jobs_with_results)
+        [self.delete_monitor_job(job.job_settings) for job in done_jobs]
+        self._save_settings()
+        return jobs_with_results
+
+
+if __name__ == "__main__":
+    o = MonitorOrchestrator()

--- a/src/transmission_client.py
+++ b/src/transmission_client.py
@@ -1,7 +1,8 @@
-from transmission_rpc import Client, Torrent, error
+from transmission_rpc import Client, Torrent, error as transmission_error
 import os
 from dotenv import load_dotenv
 from datetime import datetime
+
 load_dotenv()
 
 
@@ -57,5 +58,5 @@ if __name__ == "__main__":
         # torrents = c.get_torrents()
         for torrent in torrents:
             print(torrent)
-    except error.TransmissionConnectError:
+    except transmission_error.TransmissionConnectError:
         raise "can't connect to the host"


### PR DESCRIPTION
* refactor for consistency

* add MonitorOrchestrator

* support for regular dicts

* update settings after done job

* return type fixes

* rename PBWatcher to PBMonitor

* separate orchestrator module

* add a method to send a standalone message

* run bot and monitor together

* refactor

* added link to full search results

* monitor adding on telegram side

* manage monitors

* add one_time_keyboard

* cleanup

* manually remove keyboard on the last step of monitor setup

* rename command

* move settings data to volume for persistency

* force end converstation after monitor been added